### PR TITLE
Convert all values in the struct to JSON representations when serialising

### DIFF
--- a/lib/sidekiq/dry/client/serialization_middleware.rb
+++ b/lib/sidekiq/dry/client/serialization_middleware.rb
@@ -13,7 +13,7 @@ module Sidekiq
 
             # Set a `_type` argument to be able to instantiate
             # the struct when the job is performed
-            arg.to_h.merge(_type: arg.class.to_s).deep_stringify_keys
+            arg.to_h.merge(_type: arg.class.to_s).as_json
           end
 
           yield

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,5 +1,7 @@
 require 'sidekiq/testing'
 
+Sidekiq.strict_args!
+
 # Load all middlewares to be tested
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|

--- a/spec/support/structs.rb
+++ b/spec/support/structs.rb
@@ -3,8 +3,9 @@ module Types
 end
 
 class UserParams < Dry::Struct
-  attribute :id,     Types::Strict::Integer
-  attribute :email,  Types::Strict::String
+  attribute :id,          Types::Strict::Integer
+  attribute :email,       Types::Strict::String
+  attribute? :start_date, Types::Strict::Date
 end
 
 class UserWithAddressParams < Dry::Struct


### PR DESCRIPTION
Fixes #2 

This is so that the gem can used with Sidekiq's strict mode.